### PR TITLE
Fix inactive sword hitbox bug, update docs, reflect

### DIFF
--- a/src/attack.rs
+++ b/src/attack.rs
@@ -101,12 +101,11 @@ fn activate_hitbox(
             if animation.current_frame >= attack_frames.startup
                 && animation.current_frame <= attack_frames.active
             {
-                if let Some(attack) = available_attacks.0.last() {
-                    commands.entity(entity).insert(Collider::cuboid(
-                        attack.hitbox.size.x / 2.,
-                        attack.hitbox.size.y / 2.,
-                    ));
-                }
+                let attack = available_attacks.current_attack();
+                commands.entity(entity).insert(Collider::cuboid(
+                    attack.hitbox.size.x / 2.,
+                    attack.hitbox.size.y / 2.,
+                ));
             }
         }
     }

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -1,4 +1,9 @@
-use bevy::{hierarchy::DespawnRecursiveExt, math::Vec2, prelude::*, reflect::Reflect};
+use bevy::{
+    hierarchy::DespawnRecursiveExt,
+    math::Vec2,
+    prelude::*,
+    reflect::{FromReflect, Reflect},
+};
 use bevy_rapier2d::prelude::*;
 use iyes_loopless::prelude::*;
 
@@ -79,7 +84,7 @@ pub struct BrokeEvent {
 /// Must be added to an entity that is a child of an entity with an [`Animation`] and an [`Attack`]
 /// and will be used to spawn a collider for that attack during the `active` frames.
 /// Each field is an index refering to an animation frame
-#[derive(Component, Debug, Clone, Copy, Deserialize)]
+#[derive(Component, Debug, Clone, Copy, Deserialize, Reflect, FromReflect)]
 pub struct AttackFrames {
     pub startup: usize,
     pub active: usize,

--- a/src/fighter.rs
+++ b/src/fighter.rs
@@ -45,6 +45,8 @@ pub struct ActiveFighterBundle {
     pub available_attacks: AvailableAttacks,
 }
 
+/// Component that defines the currently available attacks on a fighter, modified at runtime when
+/// picking up and dropping items, or potentially on other conditions.
 #[derive(Component)]
 pub struct AvailableAttacks(pub Vec<AttackMeta>);
 

--- a/src/fighter.rs
+++ b/src/fighter.rs
@@ -50,7 +50,15 @@ pub struct ActiveFighterBundle {
 /// picking up and dropping items, or potentially on other conditions.
 #[derive(Component, Reflect, Clone, Default)]
 #[reflect(Component)]
-pub struct AvailableAttacks(pub Vec<AttackMeta>);
+pub struct AvailableAttacks {
+    pub attacks: Vec<AttackMeta>,
+}
+
+impl AvailableAttacks {
+    pub fn current_attack(&self) -> &AttackMeta {
+        self.attacks.last().expect("No attacks available")
+    }
+}
 
 #[derive(Component, Deserialize, Clone, Debug, Reflect)]
 #[reflect(Component)]
@@ -129,7 +137,9 @@ impl ActiveFighterBundle {
             // ysort: YSort(fighter.spritesheet.tile_size.y as f32 / 2.),
             ysort: YSort(consts::FIGHTERS_Z),
             velocity: default(),
-            available_attacks: AvailableAttacks(fighter.attacks.clone()),
+            available_attacks: AvailableAttacks {
+                attacks: fighter.attacks.clone(),
+            },
         };
         let hurtbox = commands
             .spawn_bundle(PhysicsBundle::new(&fighter.hurtbox, body_layers))

--- a/src/fighter.rs
+++ b/src/fighter.rs
@@ -21,7 +21,8 @@ pub struct FighterPlugin;
 
 impl Plugin for FighterPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system_to_stage(CoreStage::PostUpdate, attachment_system);
+        app.register_type::<AvailableAttacks>()
+            .add_system_to_stage(CoreStage::PostUpdate, attachment_system);
     }
 }
 
@@ -47,7 +48,8 @@ pub struct ActiveFighterBundle {
 
 /// Component that defines the currently available attacks on a fighter, modified at runtime when
 /// picking up and dropping items, or potentially on other conditions.
-#[derive(Component)]
+#[derive(Component, Reflect, Clone, Default)]
+#[reflect(Component)]
 pub struct AvailableAttacks(pub Vec<AttackMeta>);
 
 #[derive(Component, Deserialize, Clone, Debug, Reflect)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,7 +1,7 @@
 use bevy::{
     math::{UVec2, Vec2, Vec3},
     prelude::{Color, Component, Handle, Image},
-    reflect::TypeUuid,
+    reflect::{FromReflect, Reflect, TypeUuid},
     sprite::TextureAtlas,
     utils::HashMap,
 };
@@ -111,7 +111,7 @@ pub struct FighterMeta {
     pub attachment: Option<FighterSpritesheetMeta>,
 }
 
-#[derive(TypeUuid, Deserialize, Clone, Debug, Component)]
+#[derive(TypeUuid, Deserialize, Clone, Debug, Component, Reflect, FromReflect)]
 #[serde(deny_unknown_fields)]
 #[uuid = "45a912f4-ea5c-4eba-9ba9-f1a726140f28"]
 pub struct AttackMeta {
@@ -270,7 +270,7 @@ impl From<ParallaxLayerMeta> for LayerData {
     }
 }
 
-#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug, Reflect, FromReflect)]
 #[serde(deny_unknown_fields)]
 pub struct ColliderMeta {
     //TODO: Add type of collider with different properties.


### PR DESCRIPTION
Fixes a bug introduced when adding support for multiple attacks, adds in some reflection that was used while debugging, slightly simplified syntax for dealing with `AvailableAttacks` and added doc comment to specify its intended use.