### PR TITLE
Basic attack chaining

### DIFF
--- a/assets/fighters/dev/dev.fighter.yaml
+++ b/assets/fighters/dev/dev.fighter.yaml
@@ -38,6 +38,8 @@ spritesheet:
     attacking:
       frames: [85, 90]
     chaining:
+      frames: [112, 116]
+    followup:
       frames: [126, 131]
 
         # attacks need longer recovery vs startup
@@ -56,8 +58,8 @@ attacks:
   - name: "flop"
     damage: 50
     frames:
-      startup: 1
-      active: 2
+      startup: 0
+      active: 1
       recovery: 4
     hitbox:
       size: [32, 32]

--- a/assets/fighters/dev/dev.fighter.yaml
+++ b/assets/fighters/dev/dev.fighter.yaml
@@ -35,10 +35,12 @@ spritesheet:
       frames: [71, 76]
     dying:
       frames: [71, 76]
-    #spritesheet does not contain unique attack animation
     attacking:
       frames: [85, 90]
+    chaining:
+      frames: [126, 131]
 
+        # attacks need longer recovery vs startup
 attacks:
   - name: "punch"
     damage: 35
@@ -50,6 +52,30 @@ attacks:
       size: [32, 32]
       offset: [32, 0]
     hitstun_duration: 0.2
+
+  - name: "flop"
+    damage: 50
+    frames:
+      startup: 1
+      active: 2
+      recovery: 4
+    hitbox:
+      size: [32, 32]
+      offset: [32, 0]
+    hitstun_duration: 0.2
+
+  - name: "chain"
+    damage: 35
+    frames:
+      startup: 1
+      active: 2
+      recovery: 4
+    hitbox:
+      size: [32, 32]
+      offset: [32, 0]
+    hitstun_duration: 0.2
+
+
 
 audio:
   effects:

--- a/assets/fighters/dev/dev.fighter.yaml
+++ b/assets/fighters/dev/dev.fighter.yaml
@@ -65,10 +65,10 @@ attacks:
     hitstun_duration: 0.2
 
   - name: "chain"
-    damage: 35
+    damage: 20
     frames:
-      startup: 1
-      active: 2
+      startup: 2
+      active: 3
       recovery: 4
     hitbox:
       size: [32, 32]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -126,10 +126,6 @@ pub struct AttackMeta {
     pub item_handle: Handle<ItemMeta>,
 }
 
-// pub struct AttackChainMeta {
-// pub attacks: AttackMeta
-// }
-
 #[derive(TypeUuid, Deserialize, Clone, Debug, Component)]
 #[serde(deny_unknown_fields)]
 #[uuid = "5e2db270-ec2e-013a-92a8-2cf05d71216b"]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -126,6 +126,10 @@ pub struct AttackMeta {
     pub item_handle: Handle<ItemMeta>,
 }
 
+// pub struct AttackChainMeta {
+// pub attacks: AttackMeta
+// }
+
 #[derive(TypeUuid, Deserialize, Clone, Debug, Component)]
 #[serde(deny_unknown_fields)]
 #[uuid = "5e2db270-ec2e-013a-92a8-2cf05d71216b"]


### PR DESCRIPTION
Only works for a specific sequence of attacks for Dev fighter currently.
Hitting attack during an active "chain" attack will cancel the recovery frames (and a few startup frames on the followup) and move to the next attack.

closes #179 but requires followup work.

Followup should generalize the recovery canceling and attack chain sequence to work for any valid predefined sequence of available attacks on a fighter.