### PR TITLE
fix: fix scripting error when trying to use health item.

### DIFF
--- a/src/scripting/ops.rs
+++ b/src/scripting/ops.rs
@@ -69,7 +69,7 @@ impl JsRuntimeOp for ItemGetGrabEvents {
                 // `wrapValueRef` on each item to wrap the them in a Proxy that will make it behave
                 // like a normal JavaScript object.
                 return bevyModJsScriptingOpSync('punchyGetItemGrabEvents')
-                    .map(x => globalThis.wrapValueRef(x));
+                    .map(x => Value.wrapValueRef(x));
             }
             "#,
         )


### PR DESCRIPTION
Updates to use the new namespace for the `wrapValueRef` function in `bevy_mod_js_scripting`.

Fixes: #295