### PR TITLE
Changed hitstun to not transition state if duration is 0

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -305,7 +305,7 @@ impl AssetLoader for FighterLoader {
                     get_relative_asset(load_context, load_context.path(), image);
 
                 let atlas_handle = load_context.set_labeled_asset(
-                    format!("atlas_{}", index).as_str(),
+                    format!("atlas_{index}").as_str(),
                     LoadedAsset::new(TextureAtlas::from_grid(
                         texture_handle,
                         meta.spritesheet.tile_size.as_vec2(),
@@ -418,7 +418,7 @@ impl AssetLoader for ItemLoader {
                             get_relative_asset(load_context, load_context.path(), image);
 
                         let atlas_handle = load_context.set_labeled_asset(
-                            format!("atlas_{}", index).as_str(),
+                            format!("atlas_{index}").as_str(),
                             LoadedAsset::new(TextureAtlas::from_grid(
                                 texture_handle,
                                 spritesheet.tile_size.as_vec2(),
@@ -447,7 +447,7 @@ impl AssetLoader for ItemLoader {
                             get_relative_asset(load_context, load_context.path(), image);
 
                         let atlas_handle = load_context.set_labeled_asset(
-                            format!("atlas_{}", index).as_str(),
+                            format!("atlas_{index}").as_str(),
                             LoadedAsset::new(TextureAtlas::from_grid(
                                 texture_handle,
                                 spritesheet.tile_size.as_vec2(),

--- a/src/fighter_state.rs
+++ b/src/fighter_state.rs
@@ -484,6 +484,9 @@ fn collect_hitstuns(
     for event in damage_events.iter() {
         // If the damaged entity was a fighter
         if let Ok(mut transition_intents) = fighters.get_mut(event.damaged_entity) {
+            if event.hitstun_duration == 0.0 {
+                continue;
+            }
             // Trigger hit stun
             transition_intents.push_back(StateTransition::new(
                 HitStun {

--- a/src/ui/main_menu.rs
+++ b/src/ui/main_menu.rs
@@ -681,11 +681,11 @@ fn format_input(input: &InputKind) -> String {
             let direction = if axis.positive_low == 1.0 { "-" } else { "+" };
 
             let stick = match axis.axis_type {
-                leafwing_input_manager::axislike::AxisType::Gamepad(axis) => format!("{:?}", axis),
-                other => format!("{:?}", other),
+                leafwing_input_manager::axislike::AxisType::Gamepad(axis) => format!("{axis:?}"),
+                other => format!("{other:?}"),
             };
 
-            format!("{} {}", stick, direction)
+            format!("{stick} {direction}")
         }
         other => other.to_string(),
     }


### PR DESCRIPTION
This means we can now have attacks which apply damage but do not interrupt other actions/state. Currently in use for the slingers rock throw attack.